### PR TITLE
selected commonly used characters

### DIFF
--- a/commonly_used_data.py
+++ b/commonly_used_data.py
@@ -1,0 +1,26 @@
+import json, shutil
+
+
+characters = [] # 创建一个列表用于保存汉字字符
+for i in range(176, 216):
+    s = bytes([i])
+    for x in range(161, 255):
+        s += bytes([x])
+        try:
+            c = s.decode("gb2312")
+        except:
+            break
+        characters.append(c)
+        # print(c, end="\t") # 打印结果
+        s = bytes([i])
+        hz_json = ["\\hanzi-writer-data-master\\data\\",c,".json"]
+        shutil.copy("".join(hz_json),'.\data')
+
+print(len(characters)) # 打印结果数量
+
+filename = "common_chinese_characters.json"
+with open(filename, "w", encoding="utf-8") as f:
+    json.dump(characters, f, ensure_ascii=False)
+
+
+


### PR DESCRIPTION
According to the encode style of GB2312, the commonly used Chinese characters are in first-class and order by pinyin. So, we can select the 3000+ commonly used characters by the order.